### PR TITLE
Add support for godot_group custom property to set Group on the Node

### DIFF
--- a/CSharp/addons/YATI/TilemapCreator.cs
+++ b/CSharp/addons/YATI/TilemapCreator.cs
@@ -42,7 +42,7 @@ public class TilemapCreator
     private const string BackgroundColorRectName = "Background Color";
     private const string WarningColor = "Yellow";
     private const string CustomDataInternal = "__internal__";
-    private const string GodotProperty = "godot_node_type";
+    private const string GodotNodeTypeProperty = "godot_node_type";
     private const string DefaultAlignment = "unspecified";
 
     private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
@@ -718,7 +718,7 @@ public class TilemapCreator
             var name = (string)property.GetValueOrDefault("name", "");
             var type = (string)property.GetValueOrDefault("type", "string");
             var val = (string)property.GetValueOrDefault("value", "");
-            if (name.ToLower() != GodotProperty || type != "string") continue;
+            if (name.ToLower() != GodotNodeTypeProperty || type != "string") continue;
             propertyFound = true;
             ret = val;
             break;
@@ -770,7 +770,7 @@ public class TilemapCreator
             }
             else if (godotPropFound && godotPropertyString != "")
             {
-                GD.PrintRich($"[color={WarningColor}] -- Unknown {GodotProperty} '{godotPropertyString}'. -> Assuming Default[/color]");
+                GD.PrintRich($"[color={WarningColor}] -- Unknown {GodotNodeTypeProperty} '{godotPropertyString}'. -> Assuming Default[/color]");
                 _warningCount++;
             }
             godotType = GodotType.Body;
@@ -1798,7 +1798,7 @@ public class TilemapCreator
             var name = (string)property.GetValueOrDefault("name", "");
             var type = (string)property.GetValueOrDefault("type", "string");
             var val = (string)property.GetValueOrDefault("value", "");
-            if (name == "" || name.ToLower() == GodotProperty) continue;
+            if (name == "" || name.ToLower() == GodotNodeTypeProperty) continue;
             if (name.StartsWith("__") && hasChildren)
             {
                 var childPropDict = new Dictionary();
@@ -1812,6 +1812,13 @@ public class TilemapCreator
 
             switch (name.ToLower())
             {
+                // Node properties
+                case "godot_group" when (type == "string"):
+                    foreach (string group in val.Split(','))
+                    {
+                        targetNode.AddToGroup(group.Trim(), true)
+                    }
+                    break;
                 // CanvasItem properties
                 case "modulate" when (type == "string"):
                     ((CanvasItem)targetNode).Modulate = new Color(val);

--- a/CSharp/runtime/TilemapCreator.cs
+++ b/CSharp/runtime/TilemapCreator.cs
@@ -42,7 +42,7 @@ public class TilemapCreator
     private const string BackgroundColorRectName = "Background Color";
     private const string WarningColor = "Yellow";
     private const string CustomDataInternal = "__internal__";
-    private const string GodotProperty = "godot_node_type";
+    private const string GodotNodeTypeProperty = "godot_node_type";
     private const string DefaultAlignment = "unspecified";
 
     private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
@@ -718,7 +718,7 @@ public class TilemapCreator
             var name = (string)property.GetValueOrDefault("name", "");
             var type = (string)property.GetValueOrDefault("type", "string");
             var val = (string)property.GetValueOrDefault("value", "");
-            if (name.ToLower() != GodotProperty || type != "string") continue;
+            if (name.ToLower() != GodotNodeTypeProperty || type != "string") continue;
             propertyFound = true;
             ret = val;
             break;
@@ -770,7 +770,7 @@ public class TilemapCreator
             }
             else if (godotPropFound && godotPropertyString != "")
             {
-                GD.PrintRich($"[color={WarningColor}] -- Unknown {GodotProperty} '{godotPropertyString}'. -> Assuming Default[/color]");
+                GD.PrintRich($"[color={WarningColor}] -- Unknown {GodotNodeTypeProperty} '{godotPropertyString}'. -> Assuming Default[/color]");
                 _warningCount++;
             }
             godotType = GodotType.Body;
@@ -1798,7 +1798,7 @@ public class TilemapCreator
             var name = (string)property.GetValueOrDefault("name", "");
             var type = (string)property.GetValueOrDefault("type", "string");
             var val = (string)property.GetValueOrDefault("value", "");
-            if (name == "" || name.ToLower() == GodotProperty) continue;
+            if (name == "" || name.ToLower() == GodotNodeTypeProperty) continue;
             if (name.StartsWith("__") && hasChildren)
             {
                 var childPropDict = new Dictionary();
@@ -1812,6 +1812,13 @@ public class TilemapCreator
 
             switch (name.ToLower())
             {
+                // Node properties
+                case "godot_group" when (type == "string"):
+                    foreach (string group in val.Split(','))
+                    {
+                        targetNode.AddToGroup(group.Trim(), true)
+                    }
+                    break;
                 // CanvasItem properties
                 case "modulate" when (type == "string"):
                     ((CanvasItem)targetNode).Modulate = new Color(val);

--- a/GDScript/addons/YATI/TilemapCreator.gd
+++ b/GDScript/addons/YATI/TilemapCreator.gd
@@ -30,7 +30,8 @@ const FLIPPED_DIAGONALLY_FLAG = 0x20000000
 const BACKGROUND_COLOR_RECT_NAME = "Background Color"
 const WARNING_COLOR = "Yellow"
 const CUSTOM_DATA_INTERNAL = "__internal__"
-const GODOT_PROPERTY = "godot_node_type"
+const GODOT_NODE_TYPE_PROPERTY = "godot_node_type"
+const GODOT_GROUP_PROPERTY = "godot_group"
 const DEFAULT_ALIGNMENT = "unspecified"
 
 var _map_orientation: String
@@ -595,7 +596,7 @@ func get_godot_property(obj: Dictionary):
 			var name: String = property.get("name", "")
 			var type: String = property.get("type", "string")
 			var val: String = str(property.get("value", ""))
-			if name.to_lower() == GODOT_PROPERTY and type == "string":
+			if name.to_lower() == GODOT_NODE_TYPE_PROPERTY and type == "string":
 				property_found = true
 				ret = val
 				break
@@ -639,7 +640,7 @@ func handle_object(obj: Dictionary, layer_node: Node, tileset: TileSet, offset: 
 			print_rich("[color=" + WARNING_COLOR +"] -- Unknown class '" + class_string + "'. -> Assuming Default[/color]")
 			_warning_count += 1
 		elif godot_prop_found and godot_property_string != "":	
-			print_rich("[color=" + WARNING_COLOR +"] -- Unknown " + GODOT_PROPERTY + " '" + godot_property_string + "'. -> Assuming Default[/color]")
+			print_rich("[color=" + WARNING_COLOR +"] -- Unknown " + GODOT_NODE_TYPE_PROPERTY + " '" + godot_property_string + "'. -> Assuming Default[/color]")
 			_warning_count += 1
 		godot_type = _godot_type.BODY
 
@@ -1425,7 +1426,7 @@ func handle_properties(target_node: Node, properties: Array, map_properties: boo
 		var name: String = property.get("name", "")
 		var type: String = property.get("type", "string")
 		var val: String = str(property.get("value", ""))
-		if name == "" or name.to_lower() == GODOT_PROPERTY: continue
+		if name == "" or name.to_lower() == GODOT_NODE_TYPE_PROPERTY: continue
 		if name.begins_with("__") and has_children:
 			var child_prop_dict = {}
 			child_prop_dict["name"] = name.substr(2)
@@ -1435,9 +1436,14 @@ func handle_properties(target_node: Node, properties: Array, map_properties: boo
 			child_props.append(child_prop_dict)
 			for child in target_node.get_children():
 				handle_properties(child, child_props)
-		
+
+		# Node properties
+		if name.to_lower() == GODOT_GROUP_PROPERTY and type == "string":
+			for group in val.split(",", false):
+				target_node.add_to_group(group.strip_edges(), true)
+
 		# CanvasItem properties
-		if name.to_lower() == "modulate" and type == "string":
+		elif name.to_lower() == "modulate" and type == "string":
 			target_node.modulate = Color(val)
 		elif name.to_lower() == "self_modulate" and type == "string":
 			target_node.self_modulate = Color(val)

--- a/GDScript/runtime/TilemapCreator.gd
+++ b/GDScript/runtime/TilemapCreator.gd
@@ -29,7 +29,8 @@ const FLIPPED_DIAGONALLY_FLAG = 0x20000000
 const BACKGROUND_COLOR_RECT_NAME = "Background Color"
 const WARNING_COLOR = "Yellow"
 const CUSTOM_DATA_INTERNAL = "__internal__"
-const GODOT_PROPERTY = "godot_node_type"
+const GODOT_NODE_TYPE_PROPERTY = "godot_node_type"
+const GODOT_GROUP_PROPERTY = "godot_group"
 const DEFAULT_ALIGNMENT = "unspecified"
 
 var _map_orientation: String
@@ -594,7 +595,7 @@ func get_godot_property(obj: Dictionary):
 			var name: String = property.get("name", "")
 			var type: String = property.get("type", "string")
 			var val: String = str(property.get("value", ""))
-			if name.to_lower() == GODOT_PROPERTY and type == "string":
+			if name.to_lower() == GODOT_NODE_TYPE_PROPERTY and type == "string":
 				property_found = true
 				ret = val
 				break
@@ -638,7 +639,7 @@ func handle_object(obj: Dictionary, layer_node: Node, tileset: TileSet, offset: 
 			print_rich("[color=" + WARNING_COLOR +"] -- Unknown class '" + class_string + "'. -> Assuming Default[/color]")
 			_warning_count += 1
 		elif godot_prop_found and godot_property_string != "":	
-			print_rich("[color=" + WARNING_COLOR +"] -- Unknown " + GODOT_PROPERTY + " '" + godot_property_string + "'. -> Assuming Default[/color]")
+			print_rich("[color=" + WARNING_COLOR +"] -- Unknown " + GODOT_NODE_TYPE_PROPERTY + " '" + godot_property_string + "'. -> Assuming Default[/color]")
 			_warning_count += 1
 		godot_type = _godot_type.BODY
 
@@ -1424,7 +1425,7 @@ func handle_properties(target_node: Node, properties: Array, map_properties: boo
 		var name: String = property.get("name", "")
 		var type: String = property.get("type", "string")
 		var val: String = str(property.get("value", ""))
-		if name == "" or name.to_lower() == GODOT_PROPERTY: continue
+		if name == "" or name.to_lower() == GODOT_NODE_TYPE_PROPERTY: continue
 		if name.begins_with("__") and has_children:
 			var child_prop_dict = {}
 			child_prop_dict["name"] = name.substr(2)
@@ -1434,9 +1435,14 @@ func handle_properties(target_node: Node, properties: Array, map_properties: boo
 			child_props.append(child_prop_dict)
 			for child in target_node.get_children():
 				handle_properties(child, child_props)
-		
+
+		# Node properties
+		if name.to_lower() == GODOT_GROUP_PROPERTY and type == "string":
+			for group in val.split(",", false):
+				target_node.add_to_group(group.strip_edges(), true)
+
 		# CanvasItem properties
-		if name.to_lower() == "modulate" and type == "string":
+		elif name.to_lower() == "modulate" and type == "string":
 			target_node.modulate = Color(val)
 		elif name.to_lower() == "self_modulate" and type == "string":
 			target_node.self_modulate = Color(val)

--- a/Reference.md
+++ b/Reference.md
@@ -158,14 +158,14 @@ Coll.(*): All tile collision objects (except point), ellipse is approximated by 
 Setting these properties affects the Godot settings accordingly.  
 Custom properties which are not in this list or not fitting to the element are added as Meta Data or - if assigned to a tile - as Custom Data.
 
+There is a special custom property `godot_group` which applies to all elements and applies the group to the Node. This property supports multiple groups by comma seperating the values.
+
 Remarks:  
-(*) refers to a string consisting of comma separated values, each value representing an element number to enable.  
+- (*) refers to a string consisting of comma separated values, each value representing an element number to enable.  
 Example for a collision layer property (name+value), where layers 1,3,5,6,7 on physics layer 0 are to enable:  
 `collision_layer_0 = 1,3,5-7` (you can set ranges like 5-7 in this example)
-
-(col) refers to a string consisting of an # followed by hex (RGB) values. Example: `#4e4aff`
-
-(enum) refers to an int, value can be taken from the list
+- (col) refers to a string consisting of an # followed by hex (RGB) values. Example: `#4e4aff`
+- (enum) refers to an int, value can be taken from the list
 
 Properties with "n is layer number": if number appendix is missing, layer 0 is assumed  
 i.e. "collision_layer" is equivalent to "collision_layer_0"


### PR DESCRIPTION
This pull request adds support for a new custom property in tiled `godot_group` which will correspond to the group on the Godot Node. It supports comma separated values to enable multiple groups.

Note:

### Considerations
-  I have only tested this in gdscript and in editor. I assume the runtime and c# changes will work, but probably worth explicitly testing
- I renamed `GODOT_PROPERTY` to be more explicit now that there are more special properties
  - I renamed the constant in the c# to keep things consistent with the gdscript
- you can't use a variable in a case statement in c# which is why its hardcoded (and no variable)
- I'm not sure if that is the best place for the docs, open to suggestions

### Screenshots
in Tiled
![image](https://github.com/Kiamo2/YATI/assets/62071362/9fbca361-d4f3-4c11-9698-3fa1b35cfc3a)

in Godot
![image](https://github.com/Kiamo2/YATI/assets/62071362/e3d27459-0f59-4e90-a750-c9bfd0f92858)
 