### PR TITLE
added Custom Types Editor Feature

### DIFF
--- a/CSharp/addons/YATI/ArrayBuilder.cs
+++ b/CSharp/addons/YATI/ArrayBuilder.cs
@@ -1,0 +1,89 @@
+﻿// MIT License
+//
+// Copyright (c) 2023 Roland Helmerichs
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if TOOLS
+using System.Linq;
+using Godot;
+using Godot.Collections;
+
+public static class ArrayBuilder
+{
+    private enum FileType
+    {
+        Xml,
+        Json,
+        Unknown
+    }
+
+    public static Array GetArray(string sourceFile)
+    {
+        var checkedFile = sourceFile;
+        if (!FileAccess.FileExists(checkedFile))
+        {
+            checkedFile = sourceFile.GetBaseDir().PathJoin(sourceFile);
+            if (!FileAccess.FileExists(checkedFile))
+            {
+                GD.PrintErr($"ERROR: File '{sourceFile}' not found. -> Continuing but result may be unusable");
+                return null;
+            }
+        }
+        
+        var type = FileType.Unknown;
+        var extension = sourceFile.GetFile().GetExtension();
+        if (new[] { "tmx", "tsx", "xml", "tx" }.Contains(extension))
+            type = FileType.Xml;
+        else if (new[] { "tmj", "tsj", "json", "tj" }.Contains(extension))
+            type = FileType.Json;
+        else
+        {
+            using var file = FileAccess.Open(checkedFile, FileAccess.ModeFlags.Read);
+            var chunk = System.Text.Encoding.UTF8.GetString(file.GetBuffer(12));
+            if (chunk.StartsWith("<?xml "))
+                type = FileType.Xml;
+            else if (chunk.StartsWith("{ \""))
+                type = FileType.Json;
+        }
+
+        switch (type)
+        {
+            // case FileType.Xml:
+            // {
+            //     var dictBuilder = new DictionaryFromXml();
+            //     return dictBuilder.Create(checkedFile);
+            // }
+            case FileType.Json:
+            {
+                var json = new Json();
+                using var file = FileAccess.Open(checkedFile, FileAccess.ModeFlags.Read);
+                if (json.Parse(file.GetAsText()) == Error.Ok)
+                    return (Array)json.Data;
+                break;
+            }
+            case FileType.Unknown:
+                GD.PrintErr($"ERROR: File '{sourceFile}' has an unknown type. -> Continuing but result may be unusable");
+                break;
+        }
+
+        return null;
+    }
+}
+#endif

--- a/CSharp/addons/YATI/Importer.cs
+++ b/CSharp/addons/YATI/Importer.cs
@@ -51,6 +51,11 @@ public partial class Importer: EditorImportPlugin
             new() { { "name", "use_default_filter" }, { "default_value", false } },
             new() { { "name", "add_class_as_metadata" }, { "default_value", false } },
             new() { { "name", "map_wangset_to_terrain" }, { "default_value", false } },
+            new()
+            {
+                { "name", "custom_types_configuration_path" }, { "default_value", "" },
+                { "property_hint", (int)PropertyHint.File }, { "hint_string", "*.xml,*.json" }
+            },
             new() { { "name", "post_processor" }, { "default_value", "" },
                     { "property_hint", (int)PropertyHint.File }, { "hint_string", "*.cs;C# Script" } },
             new() { { "name", "save_tileset_to" }, { "default_value", "" },
@@ -86,6 +91,12 @@ public partial class Importer: EditorImportPlugin
             tilemapCreator.SetAddClassAsMetadata(true);
         if ((string)options["map_wangset_to_terrain"] == "true")
             tilemapCreator.SetMapWangsetToTerrain(true);
+        if (options.TryGetValue("custom_types_configuration_path", out Variant op))
+        {
+            if (op.AsString() != "")
+                tilemapCreator.SetCustomTypes(ArrayBuilder.GetArray(op.AsString()));
+        }
+
         var node2D = tilemapCreator.Create(sourceFile);
         if (node2D == null)
             return Error.Failed;


### PR DESCRIPTION
This is a hacky and probably very incomplete implementation to respect the Custom Type Editor in Tiled.

I used SuperTiled2Unity in Unity, which uses the Custom Types in Tiled. So implemented it here. It works cascading, so it will first look up the property in Custom Type and then local override. I put down a bunch of screenshots.

It is only implemented in C# and would need an implementation in GDScript. I don't mind if you deny that pull request and make your own implementation I made a fork to stay on a par with your version.

![grafik](https://github.com/Kiamo2/YATI/assets/601797/294bcb48-dfe9-4dfd-8fab-d9dee309d166)

Showing Custom Types in Tiled

![grafik](https://github.com/Kiamo2/YATI/assets/601797/a38c7ca8-ecd6-4aa7-8aa2-291e596d07ea)

You need to export the object types as json in Tiled and set it there as include.