### PR TITLE
Support script property

### DIFF
--- a/CSharp/addons/YATI/TilemapCreator.cs
+++ b/CSharp/addons/YATI/TilemapCreator.cs
@@ -46,6 +46,7 @@ public class TilemapCreator
     private const string CustomDataInternal = "__internal__";
     private const string GodotNodeTypeProperty = "godot_node_type";
     private const string GodotGroupProperty = "godot_group";
+    private const string GodotScriptProperty = "godot_script";
     private const string DefaultAlignment = "unspecified";
 
     private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
@@ -1907,7 +1908,7 @@ public class TilemapCreator
                     break;
 
                 // v1.6.x: script resource and property
-                case "script" when (type == "file"):
+                case GodotScriptProperty when (type == "file"):
                     targetNode.SetScript((Script)ResourceLoader.Load(val, "Script"));
                     break;
 

--- a/CSharp/addons/YATI/TilemapCreator.cs
+++ b/CSharp/addons/YATI/TilemapCreator.cs
@@ -1906,6 +1906,11 @@ public class TilemapCreator
                         targetNode.AddToGroup(group.Trim(), true);
                     break;
 
+                // v1.6.x: script resource and property
+                case "script" when (type == "file"):
+                    targetNode.SetScript((Script)ResourceLoader.Load(val, "Script"));
+                    break;
+
                 // CanvasItem properties
                 case "modulate" when (type == "string"):
                     ((CanvasItem)targetNode).Modulate = new Color(val);

--- a/CSharp/runtime/TilemapCreator.cs
+++ b/CSharp/runtime/TilemapCreator.cs
@@ -1904,6 +1904,11 @@ public class TilemapCreator
                         targetNode.AddToGroup(group.Trim(), true);
                     break;
 
+                // v1.6.x: script resource and property
+                case "script" when (type == "file"):
+                    targetNode.SetScript((Script)ResourceLoader.Load(val, "Script"));
+                    break;
+
                 // CanvasItem properties
                 case "modulate" when (type == "string"):
                     ((CanvasItem)targetNode).Modulate = new Color(val);

--- a/CSharp/runtime/TilemapCreator.cs
+++ b/CSharp/runtime/TilemapCreator.cs
@@ -44,6 +44,7 @@ public class TilemapCreator
     private const string CustomDataInternal = "__internal__";
     private const string GodotNodeTypeProperty = "godot_node_type";
     private const string GodotGroupProperty = "godot_group";
+    private const string GodotScriptProperty = "godot_script";
     private const string DefaultAlignment = "unspecified";
 
     private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
@@ -1905,7 +1906,7 @@ public class TilemapCreator
                     break;
 
                 // v1.6.x: script resource and property
-                case "script" when (type == "file"):
+                case GodotScriptProperty when (type == "file"):
                     targetNode.SetScript((Script)ResourceLoader.Load(val, "Script"));
                     break;
 

--- a/GDScript/addons/YATI/TilemapCreator.gd
+++ b/GDScript/addons/YATI/TilemapCreator.gd
@@ -32,6 +32,7 @@ const WARNING_COLOR = "Yellow"
 const CUSTOM_DATA_INTERNAL = "__internal__"
 const GODOT_NODE_TYPE_PROPERTY = "godot_node_type"
 const GODOT_GROUP_PROPERTY = "godot_group"
+const GODOT_SCRIPT_PROPERTY = "godot_script"
 const DEFAULT_ALIGNMENT = "unspecified"
 
 var _map_orientation: String
@@ -1532,7 +1533,7 @@ func handle_properties(target_node: Node, properties: Array, map_properties: boo
 				target_node.add_to_group(group.strip_edges(), true)
 
 		# v1.6.x: script resource and property
-		if name.to_lower() == "script" and type == "file":
+		if name.to_lower() == GODOT_SCRIPT_PROPERTY and type == "file":
 			target_node.set_script(load(val))
 
 		# CanvasItem properties

--- a/GDScript/addons/YATI/TilemapCreator.gd
+++ b/GDScript/addons/YATI/TilemapCreator.gd
@@ -1531,6 +1531,10 @@ func handle_properties(target_node: Node, properties: Array, map_properties: boo
 			for group in val.split(",", false):
 				target_node.add_to_group(group.strip_edges(), true)
 
+		# v1.6.x: script resource and property
+		if name.to_lower() == "script" and type == "file":
+			target_node.set_script(load(val))
+
 		# CanvasItem properties
 		elif name.to_lower() == "modulate" and type == "string":
 			target_node.modulate = Color(val)

--- a/GDScript/runtime/TilemapCreator.gd
+++ b/GDScript/runtime/TilemapCreator.gd
@@ -31,6 +31,7 @@ const WARNING_COLOR = "Yellow"
 const CUSTOM_DATA_INTERNAL = "__internal__"
 const GODOT_NODE_TYPE_PROPERTY = "godot_node_type"
 const GODOT_GROUP_PROPERTY = "godot_group"
+GODOT_SCRIPT_PROPERTY = "godot_script"
 const DEFAULT_ALIGNMENT = "unspecified"
 
 var _map_orientation: String
@@ -1531,7 +1532,7 @@ func handle_properties(target_node: Node, properties: Array, map_properties: boo
 				target_node.add_to_group(group.strip_edges(), true)
 
 		# v1.6.x: script resource and property
-		if name.to_lower() == "script" and type == "file":
+		if name.to_lower() == GODOT_SCRIPT_PROPERTY and type == "file":
 			target_node.set_script(load(val))
 
 		# CanvasItem properties

--- a/GDScript/runtime/TilemapCreator.gd
+++ b/GDScript/runtime/TilemapCreator.gd
@@ -31,7 +31,7 @@ const WARNING_COLOR = "Yellow"
 const CUSTOM_DATA_INTERNAL = "__internal__"
 const GODOT_NODE_TYPE_PROPERTY = "godot_node_type"
 const GODOT_GROUP_PROPERTY = "godot_group"
-GODOT_SCRIPT_PROPERTY = "godot_script"
+const GODOT_SCRIPT_PROPERTY = "godot_script"
 const DEFAULT_ALIGNMENT = "unspecified"
 
 var _map_orientation: String

--- a/GDScript/runtime/TilemapCreator.gd
+++ b/GDScript/runtime/TilemapCreator.gd
@@ -1530,6 +1530,10 @@ func handle_properties(target_node: Node, properties: Array, map_properties: boo
 			for group in val.split(",", false):
 				target_node.add_to_group(group.strip_edges(), true)
 
+		# v1.6.x: script resource and property
+		if name.to_lower() == "script" and type == "file":
+			target_node.set_script(load(val))
+
 		# CanvasItem properties
 		elif name.to_lower() == "modulate" and type == "string":
 			target_node.modulate = Color(val)


### PR DESCRIPTION
This allows you to set a `script` property inside Tiled that is then set on an imported Node. This means YATI can continue doing its existing imports and conversions, translating Tiled position and sizes, and users can attach a script to them just as they would later in Godot.

Marked as a draft, as this is my first PR here; want and am very ready and open for feedback.

I still need to make a commit to update the docs and better test the C# code.