### PR TITLE
Fixed: Removed preload of CustomTypes

### DIFF
--- a/GDScript/addons/YATI/Importer.gd
+++ b/GDScript/addons/YATI/Importer.gd
@@ -87,7 +87,7 @@ func _import(source_file: String, save_path: String, options: Dictionary, platfo
 	if options["map_wangset_to_terrain"] == true:
 		tilemapCreator.set_map_wangset_to_terrain(true)
 	if options.has("tiled_project_file") and options["tiled_project_file"] != "":
-		ct = preload("CustomTypes.gd").new()
+		ct = CustomTypes.new()
 		ct.load_custom_types(options["tiled_project_file"])
 		tilemapCreator.set_custom_types(ct)
 

--- a/GDScript/runtime/Importer.gd
+++ b/GDScript/runtime/Importer.gd
@@ -25,7 +25,7 @@ func import(source_file: String, project_file: String = ""):
 	tilemapCreator.set_map_layers_to_tilemaps(true)
 	tilemapCreator.set_add_class_as_metadata(true)
 	if project_file != "":
-		var ct = preload("CustomTypes.gd").new()
+		var ct = CustomTypes.new()
 		ct.load_custom_types(project_file)
 		tilemapCreator.set_custom_types(ct)
 	return tilemapCreator.create(source_file)


### PR DESCRIPTION
The `preload()` function appears to load CustomTypes into the global namespace causing a problem with when it is created. I switched it to remove the preload and instead instantiate the class.

Note: I did test it on the non-runtime version. If you have a runtime version to test it on it could be good. The logic is essentially the same though.

Ref:
https://github.com/Kiamo2/YATI/issues/46