### PR TITLE
Automatically keep only mandatory files for download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,4 +15,4 @@ CSharp/runtime/TilesetCreator.cs linguist-detectable=false
 * export-ignore
 
 # But not the GDScript folder (chose this one by default since the majority of users will go for this one).
-GDScript/* export-included
+GDScript/addons/* export-included

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,12 @@ CSharp/runtime/DictionaryBuilder.cs linguist-detectable=false
 CSharp/runtime/DictionaryFromXml.cs linguist-detectable=false
 CSharp/runtime/Importer.cs linguist-detectable=false
 CSharp/runtime/TilesetCreator.cs linguist-detectable=false
+
+# Exclude all top-level files and directories (except addons) from ZIP downloads.
+# This makes installing through the AssetLib easier, because no files and folders need to be unchecked.
+
+# Ignore everything by default since the repo got a lot of files
+* export-ignore
+
+# But not the GDScript folder (chose this one by default since the majority of users will go for this one).
+GDScript/* export-included


### PR DESCRIPTION
**Didn't test it, so before merging please test.**

But if it's working as intended, this should allows the generated zip to only contain the mandatory files to make the gdscript plugin version work in godot.

