### PR TITLE
Copy properties to created alternative tiles

### DIFF
--- a/GDScript/addons/YATI/TilemapCreator.gd
+++ b/GDScript/addons/YATI/TilemapCreator.gd
@@ -503,6 +503,9 @@ func create_polygons_on_alternative_tiles(source_data: TileData, target_data: Ti
 		var occluder_polygon = OccluderPolygon2D.new()
 		occluder_polygon.polygon = pts_new
 		target_data.set_occluder(layer_id, occluder_polygon)
+	# Copy properties to created alternative tile
+	for name in source_data.get_meta_list():
+		target_data.set_meta(name, source_data.get_meta(name))
 		
 
 func create_map_from_data(layer_data: Array, offset_x: int, offset_y: int, map_width: int):


### PR DESCRIPTION
When _dont_use_alternative_tiles is disabled, the created alternative tiles doesn't preserve the custom properties added in Tiled. This PR addresses this issue by ensuring that custom properties are retained when creating new alternative tiles.