### PR TITLE
TileMapLayers now have the `collision_layer` and `collision_mask` set with those properties.

### DIFF
--- a/GDScript/addons/YATI/TilemapCreator.gd
+++ b/GDScript/addons/YATI/TilemapCreator.gd
@@ -1868,6 +1868,12 @@ func handle_properties(target_node: Node, properties: Array):
 		elif name.to_lower() == "gizmo_extents" and (type == "float" or type == "int") and target_node is Marker2D:
 			target_node.gizmo_extents = float(val)
 
+		# TilemapLayer properties
+		elif name.to_lower() == "collision_layer" and type == "string" and target_node is TileMapLayer:
+			target_node.tile_set.set_physics_layer_collision_layer(0, get_bitmask_integer_from_string(val, 32))
+		elif name.to_lower() == "collision_mask" and type == "string" and target_node is TileMapLayer:
+			target_node.tile_set.set_physics_layer_collision_mask(0, get_bitmask_integer_from_string(val, 32))
+
 		# Other properties are added as Metadata
 		else:
 			target_node.set_meta(name, get_right_typed_value(type, val))


### PR DESCRIPTION
This PR adds `collision_layer` and `collision_mask` properties to the `TileSet` if those properties are added to a `tilemap`.

**EDIT**: After posting this PR, I have realized that this is *not* intended behavior, and that this should only work on `tilesets`, which doesn't actually work.