### PR TITLE
Update TilemapCreator.gd

### DIFF
--- a/GDScript/addons/YATI/TilemapCreator.gd
+++ b/GDScript/addons/YATI/TilemapCreator.gd
@@ -790,7 +790,7 @@ func handle_object(obj: Dictionary, layer_node: Node, tileset: TileSet, offset: 
 	if obj.has("template"):
 		var template_dict: Dictionary
 		var template_file = obj["template"]
-		var template_path = _base_path.path_join(template_file).get_base_dir()
+		var template_path = _base_path.path_join(template_file)
 		var template_content = DataLoader.get_tiled_file_content(template_file, _base_path)
 		if template_content == null:
 			printerr("ERROR: Template file '" + template_file + "' not found. -> Continuing but result may be unusable")


### PR DESCRIPTION
Fixing template paths being move two positions up in the file path, instead of one, causing them to fail with "cannot find file" errors when not in Godot root path, as reported in issue #80
