### PR TITLE
Update TilemapCreator.cs

### DIFF
--- a/CSharp/addons/YATI/TilemapCreator.cs
+++ b/CSharp/addons/YATI/TilemapCreator.cs
@@ -947,7 +947,7 @@ public class TilemapCreator
         {
 			Dictionary templateDict;
             var templateFile = (string)tplVal;
-            var templatePath = _basePath.PathJoin(templateFile).GetBaseDir();
+            var templatePath = _basePath.PathJoin(templateFile);
 			var templateContent = DataLoader.GetTiledFileContent(templateFile, _basePath);
 			if (templateContent == null)
 			{


### PR DESCRIPTION
Fixing template paths being move two positions up in the file path, instead of one, causing them to fail with "cannot find file" errors when not in Godot root path, as reported in issue #80 